### PR TITLE
Use correct number of parts in pixel_key.

### DIFF
--- a/index.js
+++ b/index.js
@@ -140,7 +140,7 @@ Bridge.getRaster = function(source, map, z, x, y, callback) {
                 var r = pixel & 0xff;
                 var g = (pixel>>>8) & 0xff;
                 var b = (pixel>>>16) & 0xff;
-                pixel_key = 'webp' + ',' +  r +','+ g + ',' + b + ',' + a;
+                pixel_key = r +','+ g + ',' + b + ',' + a;
             }
 
             view.encode('webp', {}, function(err, buffer) {


### PR DESCRIPTION
Fixes subtle bug where upstream tilelive copy could treat a solid tile with a 0 value in B channel as empty.
