### PR TITLE
add usage example to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,3 +8,32 @@ Implements the tilelive API for generating mapnik vector tiles from traditional 
 
 - *xml*: a Mapnik XML string that will be used to generate vector tiles.
 - *base*: Optional, basepath for Mapnik map. Defaults to `__dirname`.
+
+## Installation
+
+    npm install tilelive-bridge
+
+Though `tilelive` is not a dependency of `tilelive-bridge` you will want to
+install it to actually make use of `tilelive-bridge` through a reasonable
+API.
+
+## Usage
+
+```javascript
+var tilelive = require('tilelive');
+require('tilelive-bridge').registerProtocols(tilelive);
+
+tilelive.load('bridge:///path/to/file.xml', function(err, source) {
+    if (err) throw err;
+
+    // Interface is in XYZ/Google coordinates.
+    // Use `y = (1 << z) - 1 - y` to flip TMS coordinates.
+    source.getTile(0, 0, 0, function(err, tile, headers) {
+        // `err` is an error object when generation failed, otherwise null.
+        // `tile` contains the compressed image file as a Buffer
+        // `headers` is a hash with HTTP headers for the image.
+    });
+
+    // The `.getGrid` is implemented accordingly.
+});
+```


### PR DESCRIPTION
Added a usage example to match readme in the tilelive-mapnik repo. The main benefit of this is to clarify the use of "bridge" as the required protocol.