### PR TITLE
Make bufferSize configurable

### DIFF
--- a/index.js
+++ b/index.js
@@ -72,8 +72,13 @@ Bridge.prototype.update = function(opts, callback) {
     // Unset type. Will be re-set on first getTile.
     this._type = undefined;
     this._xml = opts.xml;
+
+    var bufferSize = 256;
+    if (opts.bufferSize !== undefined) {
+        bufferSize = +opts.bufferSize;
+    }
     this._map = mapnikPool.fromString(this._xml,
-        { size: 256, bufferSize: 256 },
+        { size: 256, bufferSize: bufferSize },
         { strict: false, base: this._base + '/' });
     // If no nextTick the stale pool can be used to acquire new maps.
     return immediate(function() {

--- a/test/test.js
+++ b/test/test.js
@@ -53,13 +53,46 @@ var rasterxml = {
             assert.end();
         });
     });
-    tape('should load query params', function(assert) {
-        new Bridge('bridge://' + path.resolve(path.join(__dirname,'/test-a.xml?blank=1')), function(err, source) {
+    tape('should have proper default params', function(assert) {
+        new Bridge('bridge://' + path.resolve(path.join(__dirname,'/test-a.xml')), function(err, source) {
+            assert.ifError(err);
+            assert.equal(source._blank, false);
+            assert.equal(source._xml, xml.a);
+            assert.equal(source._base, __dirname);
+            source._map.acquire(function(err, map) {
+                assert.ifError(err);
+                assert.equal(map.bufferSize, 256);
+                source._map.release(map);
+                assert.end();
+            });
+        });
+    });
+    tape('should load query params from url', function(assert) {
+        new Bridge('bridge://' + path.resolve(path.join(__dirname,'/test-a.xml?blank=1&bufferSize=10')), function(err, source) {
             assert.ifError(err);
             assert.equal(source._blank, true);
             assert.equal(source._xml, xml.a);
             assert.equal(source._base, __dirname);
-            assert.end();
+            source._map.acquire(function(err, map) {
+                assert.ifError(err);
+                assert.equal(map.bufferSize, 10);
+                source._map.release(map);
+                assert.end();
+            });
+        });
+    });
+    tape('should load query params from url', function(assert) {
+        new Bridge({ xml: xml.a, base: path.join(__dirname, '/'), blank: true, bufferSize: 10 }, function(err, source) {
+            assert.ifError(err);
+            assert.equal(source._blank, true);
+            assert.equal(source._xml, xml.a);
+            assert.equal(source._base, __dirname);
+            source._map.acquire(function(err, map) {
+                assert.ifError(err);
+                assert.equal(map.bufferSize, 10);
+                source._map.release(map);
+                assert.end();
+            });
         });
     });
     tape('#open should call all listeners', function(assert) {


### PR DESCRIPTION
A large buffer limits geometry clipping, but also severely limits performance due to over-rendering of features outside the relevant tile.  Making it configurable allows for case-by-case optimization.