### PR TITLE
Upgrade to latest node-mapnik APIs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changlog
 
+## 1.5.0
+
+ - Update to mapnik 3.4.6
+
 ## 1.4.0
 
  - Update to mapnik 3.4.x.

--- a/index.js
+++ b/index.js
@@ -196,7 +196,7 @@ Bridge.getVector = function(source, map, z, x, y, callback) {
         if (err) return callback(err);
         image.isSolid(function(err, solid, key) {
             if (err) return callback(err);
-
+            var painted = image.painted();
             var buffer = image.getData();
             // we no longer need the vtile data, so purge it now
             // to keep memory low and trigger less gc churn
@@ -210,7 +210,7 @@ Bridge.getVector = function(source, map, z, x, y, callback) {
                     if (solid === false) return callback(err, pbfz, headers);
 
                     // Empty tiles are equivalent to no tile.
-                    if (source._blank || !key) return callback(new Error('Tile does not exist'));
+                    if (source._blank || (!key && !painted)) return callback(new Error('Tile does not exist'));
 
                     pbfz.solid = key;
 

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     }
   ],
   "dependencies": {
-    "mapnik": "~3.4.1",
+    "mapnik": "https://github.com/mapnik/node-mapnik/tarball/master",
     "sphericalmercator": "1.0.x",
     "mapnik-pool": "0.1.x"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tilelive-bridge",
-  "version": "1.4.2",
+  "version": "1.5.0",
   "main": "./index.js",
   "description": "Datasource => vector tiles bridge backend for tilelive",
   "repository": {
@@ -13,7 +13,7 @@
     }
   ],
   "dependencies": {
-    "mapnik": "https://github.com/mapnik/node-mapnik/tarball/master",
+    "mapnik": "~3.4.6",
     "sphericalmercator": "1.0.x",
     "mapnik-pool": "0.1.x"
   },


### PR DESCRIPTION
 - Leverages upcoming `painted` fix for smarter pyramid tiling
 - Leverages new gzip support in `getData` to avoid uncompressed buffer being passed through JS
 - Drops `vtile.clear()` because this not longer (needs) to do anything because no internal memory is allocation now that protozero is used instead of libprotobuf