### PR TITLE
Updated the way that painted works

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changlog
 
+## 1.6.0
+
+ - Return a header that will notify tilelive if vector data is painted.
+
 ## 1.5.1
 
  - Removed bad checked if image is painted to determine if it is empty or not as this

--- a/index.js
+++ b/index.js
@@ -199,11 +199,17 @@ Bridge.getVector = function(source, map, z, x, y, callback) {
                 if (err) return callback(err);
                 headers['Content-Encoding'] = 'gzip';
 
+                pbfz.painted = image.painted();
                 // Solid handling.
                 if (solid === false) return callback(err, pbfz, headers);
 
                 // Empty tiles are equivalent to no tile.
-                if (source._blank || (!key && !image.painted())) return callback(new Error('Tile does not exist'));
+                if (source._blank || !key) 
+                {
+                    var err = new Error('Tile does not exist');
+                    err.painted = pbfz.painted;
+                    return callback(err);
+                }
 
                 pbfz.solid = key;
 

--- a/index.js
+++ b/index.js
@@ -199,17 +199,12 @@ Bridge.getVector = function(source, map, z, x, y, callback) {
                 if (err) return callback(err);
                 headers['Content-Encoding'] = 'gzip';
 
-                pbfz.painted = image.painted();
+                headers['x-tilelive-contains-data'] = image.painted();
                 // Solid handling.
                 if (solid === false) return callback(err, pbfz, headers);
 
                 // Empty tiles are equivalent to no tile.
-                if (source._blank || !key) 
-                {
-                    var err = new Error('Tile does not exist');
-                    err.painted = pbfz.painted;
-                    return callback(err);
-                }
+                if (source._blank || !key) return callback(new Error('Tile does not exist'), null, headers);
 
                 pbfz.solid = key;
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tilelive-bridge",
-  "version": "1.5.1",
+  "version": "1.6.0",
   "main": "./index.js",
   "description": "Datasource => vector tiles bridge backend for tilelive",
   "repository": {


### PR DESCRIPTION
Update the way in which tilelive-bridge uses `painted` so that it is a variable that is passed on to tilelive.

/cc @yhahn @rclark 