### PR TITLE
Pool images to reduce allocations and gc overhead

### DIFF
--- a/test/test.js
+++ b/test/test.js
@@ -216,7 +216,12 @@ function compare_vtiles(assert,filepath,vtile1,vtile2) {
     });
     Object.keys(tests).forEach(function(source) {
         tape('teardown', function(assert) {
-            sources[source].close(function() {
+            var s = sources[source];
+            assert.equal(1,s._map.getPoolSize());
+            assert.equal(0,s._im.getPoolSize());
+            s.close(function() {
+                assert.equal(0,s._map.getPoolSize());
+                assert.equal(0,s._im.getPoolSize());
                 assert.end();
             });
         });
@@ -273,7 +278,12 @@ function compare_vtiles(assert,filepath,vtile1,vtile2) {
     });
     Object.keys(tests).forEach(function(source) {
         tape('teardown', function(assert) {
-            sources[source].close(function() {
+            var s = sources[source];
+            assert.equal(1,s._map.getPoolSize());
+            assert.equal(1,s._im.getPoolSize());
+            s.close(function() {
+                assert.equal(0,s._map.getPoolSize());
+                assert.equal(0,s._im.getPoolSize());
                 assert.end();
             });
         });
@@ -397,7 +407,11 @@ function compare_vtiles(assert,filepath,vtile1,vtile2) {
         });
     });
     tape('itp teardown', function(assert) {
+        assert.equal(0,source._map.getPoolSize());
+        assert.equal(0,source._im.getPoolSize());
         source.close(function() {
+            assert.equal(0,source._map.getPoolSize());
+            assert.equal(0,source._im.getPoolSize());
             assert.end();
         });
     });


### PR DESCRIPTION
This reduces the need to allocate an image for every tile rendered.

Rather we re-use the same pixels and just clear them beforehand (which is much cheaper than re-allocating). This is able to drop memory usage from the > 1.5 GB range to just 80 MB for one render I've been testing at z19. For reference this same render used 700 MB before mapnik/node-mapnik@b7b1ec5. But I don't think the solution is to revert mapnik/node-mapnik@b7b1ec5 but rather just avoid as much allocation (which is what this pull does).

 - [x] update https://github.com/mapbox/gdal-tiling-bench/blob/master/mapnik-versions/latest/package.json#L7 after merge