### PR TITLE
Fix for blank mode

### DIFF
--- a/index.js
+++ b/index.js
@@ -265,8 +265,14 @@ Bridge.getVector = function(source, map, z, x, y, callback) {
                     return callback(err, pbfz, headers);
                 }
 
+                // In blank mode solid + painted tiles are treated as empty.
+                if (source._blank) {
+                    headers['x-tilelive-contains-data'] = false;
+                    return callback(new Error('Tile does not exist'), null, headers);
+                }
+
                 // Empty tiles are equivalent to no tile.
-                if (source._blank || !key) {
+                if (!key) {
                     return callback(new Error('Tile does not exist'), null, headers);
                 }
 

--- a/test/test.js
+++ b/test/test.js
@@ -248,6 +248,7 @@ function compare_vtiles(assert,filepath,vtile1,vtile2) {
                     // Test that empty tiles are so.
                     if (obj.empty) {
                         assert.equal(err.message, 'Tile does not exist');
+                        assert.equal(headers['x-tilelive-contains-data'], false);
                         return assert.end();
                     }
 


### PR DESCRIPTION
As of these two changes:

- https://github.com/mapbox/tilelive-bridge/pull/60
- https://github.com/mapbox/tilelive/pull/144

Blank mode essentially stopped working as solid tiles would always have this header set disallowing them from being skipped.

In blank mode solid tiles need to be treated as fully blank -- this updates the test assertion to confirm this is the case and then fixes the logic around this as well.

cc @flippmoke 