### PR TITLE
Wait 5s max for source.close() before returning a time out error

### DIFF
--- a/index.js
+++ b/index.js
@@ -125,12 +125,15 @@ Bridge.prototype.close = function(callback) {
     // a source cannot be closed fully during a copy or other operation. For
     // now error out in these scenarios as a close timeout.
     setTimeout(function() {
-        callback && callback(new Error('Source resource pool drain timed out after 5s'));
+        if (!callback) return;
+        console.warn(new Error('Source resource pool drain timed out after 5s'));
+        callback();
         callback = false;
     }, 5000);
     poolDrain(this._map,function() {
         poolDrain(this._im,function() {
-            callback && callback();
+            if (!callback) return;
+            callback();
             callback = false;
         });
     }.bind(this));

--- a/index.js
+++ b/index.js
@@ -120,8 +120,19 @@ function poolDrain(pool,callback) {
 }
 
 Bridge.prototype.close = function(callback) {
+    // For currently unknown reasons map objects can currently be acquired
+    // without being released under certain circumstances. When this occurs
+    // a source cannot be closed fully during a copy or other operation. For
+    // now error out in these scenarios as a close timeout.
+    setTimeout(function() {
+        callback && callback(new Error('Source resource pool drain timed out after 5s'));
+        callback = false;
+    }, 5000);
     poolDrain(this._map,function() {
-        poolDrain(this._im,callback);
+        poolDrain(this._im,function() {
+            callback && callback();
+            callback = false;
+        });
     }.bind(this));
 };
 

--- a/test/close-timeout.test.js
+++ b/test/close-timeout.test.js
@@ -1,0 +1,29 @@
+var Bridge = require('..');
+var path = require('path');
+var fs = require('fs');
+var tape = require('tape');
+
+tape('should timeout on close', function(assert) {
+    var xml = fs.readFileSync(path.resolve(path.join(__dirname,'/test-a.xml')), 'utf8');
+    new Bridge({ xml: xml, base:path.join(__dirname,'/') }, function(err, source) {
+        assert.ifError(err);
+        assert.ok(source);
+
+        var map;
+        source._map.acquire(function(err, m) {
+            assert.ifError(err);
+            assert.ok(m, 'acquires map');
+            map = m;
+        });
+
+        source.close(function(err) {
+            assert.equal(err.toString(), 'Error: Source resource pool drain timed out after 5s');
+
+            // release map so node process ends
+            source._map.release(map);
+
+            assert.end();
+        });
+    });
+});
+

--- a/test/close-timeout.test.js
+++ b/test/close-timeout.test.js
@@ -4,7 +4,11 @@ var fs = require('fs');
 var tape = require('tape');
 
 tape('should timeout on close', function(assert) {
+    var warn = console.warn;
     var xml = fs.readFileSync(path.resolve(path.join(__dirname,'/test-a.xml')), 'utf8');
+    console.warn = function(err) {
+        assert.equal(err.toString(), 'Error: Source resource pool drain timed out after 5s', 'warns with timeout err');
+    };
     new Bridge({ xml: xml, base:path.join(__dirname,'/') }, function(err, source) {
         assert.ifError(err);
         assert.ok(source);
@@ -17,7 +21,8 @@ tape('should timeout on close', function(assert) {
         });
 
         source.close(function(err) {
-            assert.equal(err.toString(), 'Error: Source resource pool drain timed out after 5s');
+            assert.ifError(err);
+            console.warn = warn;
 
             // release map so node process ends
             source._map.release(map);


### PR DESCRIPTION
- [x] Use IRL

------

If it's clear there's map objects not getting released I may roll a debug branch that attaches more information to each map object after its acquisition so we can inspect the uncooperative pool at close time (tile zxy?)

cc @rclark @GretaCB @springmeyer 