### PR TITLE
Handle Mapnik errors when creating VT

### DIFF
--- a/index.js
+++ b/index.js
@@ -242,7 +242,7 @@ Bridge.getVector = function(source, map, z, x, y, callback) {
         // are out of bounds at zoom-level z
         var vtile = new mapnik.VectorTile(+z,+x,+y, {buffer_size:16*map.bufferSize});
     } catch(err) {
-        return callback(err, null, headers);
+        return callback(invalid(err.message, null, headers));
     }
     
     map.extent = vtile.extent();
@@ -465,3 +465,9 @@ Bridge.prototype.getIndexableDocs = function(pointer, callback) {
         feature();
     });
 };
+
+function invalid(msg) {
+    var err = new Error(msg);
+    err.code = 'EINVALID';
+    return err;
+}


### PR DESCRIPTION
With recent Vector Tile v2 spec updates, Mapnik is now throwing on errors that previously did not throw. 

This PR helps handle these errors gracefully with a more explicit error code `EINVALID` for expected errors (errors that do not need to throw).

cc @springmeyer @BergWerkGIS @rclark 