### PR TITLE
Fix windows binary install

### DIFF
--- a/scripts/build-appveyor.bat
+++ b/scripts/build-appveyor.bat
@@ -62,7 +62,7 @@ IF /I "%NPM_BIN_DIR%"=="%CD%" ECHO ERROR npm bin -g equals local directory && SE
 ECHO ===== where npm puts stuff END ============
 
 
-ECHO calling npm install && CALL npm install --loglevel=http
+ECHO calling npm install && CALL npm install --fallback-to-build=false --toolset=v140 --loglevel=http
 IF %ERRORLEVEL% NEQ 0 GOTO ERROR
 
 ECHO calling npm test && CALL npm test


### PR DESCRIPTION
This was a lurking bug that surfaced due to changes in the node-mapnik packaging. We are not properly installing the v140 binaries (built with vs 2015 against the node from https://github.com/mapbox/node-cpp11). This is the only current windows binaries that work predictably with node-mapnik.