### PR TITLE
[WIP] Allow throwing error on max vtile size  + logging large tiles

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,4 +40,8 @@ tilelive.load('bridge:///path/to/file.xml', function(err, source) {
 });
 ```
 
-If you'd like to get statistics about tiles above a certain byte size, you can provide the `BRIDGE_LOG_MAX_VTILE_BYTES_COMPRESSED=n` environment variable in your tilelive-driven application and this will generate a stats object on you file system named `tilelive-bridge-stats.json` which includes the average tile size, the maximum tile size, and the number of tiles greater than the threshold set with the environment variable.
+### Limiting tile sizes
+
+You can set a limit to the size of vector tiles created (in bytes) by setting the `BRIDGE_MAX_VTILE_BYTES_COMPRESSED=n` environment variable. If a tile is generated and larger than the threshold, the process will return `Tile >= max allowed size` as an error.
+
+If you'd like to get statistics about tiles above a certain byte size (before limiting with the above), you can provide the `BRIDGE_LOG_MAX_VTILE_BYTES_COMPRESSED=n` environment variable in your tilelive-driven application and this will generate a stats object on you file system named `tilelive-bridge-stats.json` which includes the average tile size, the maximum tile size, and the number of tiles greater than the threshold set with the environment variable.

--- a/README.md
+++ b/README.md
@@ -39,3 +39,5 @@ tilelive.load('bridge:///path/to/file.xml', function(err, source) {
     // The `.getGrid` is implemented accordingly.
 });
 ```
+
+If you'd like to get statistics about tiles above a certain byte size, you can provide the `BRIDGE_LOG_MAX_VTILE_BYTES_COMPRESSED=n` environment variable in your tilelive-driven application and this will generate a stats object on you file system named `tilelive-bridge-stats.json` which includes the average tile size, the maximum tile size, and the number of tiles greater than the threshold set with the environment variable.

--- a/index.js
+++ b/index.js
@@ -31,6 +31,7 @@ var ImagePool = function(size) {
 module.exports = Bridge;
 
 function Bridge(uri, callback) {
+    this.BRIDGE_MAX_VTILE_BYTES_COMPRESSED = process.env.BRIDGE_MAX_VTILE_BYTES_COMPRESSED ? +process.env.BRIDGE_MAX_VTILE_BYTES_COMPRESSED : 0;
     var source = this;
 
     if (typeof uri === 'string' || (uri.protocol && !uri.xml)) {
@@ -290,6 +291,9 @@ Bridge.getVector = function(source, map, z, x, y, callback) {
         vtile.getData({compression:'gzip'}, function(err, pbfz) {
             if (err) return callback(err);
             headers['Content-Encoding'] = 'gzip';
+            if (source.BRIDGE_MAX_VTILE_BYTES_COMPRESSED > 0 && pbfz.length > source.BRIDGE_MAX_VTILE_BYTES_COMPRESSED) {
+                return callback(new Error("Tile >= max allowed size"), pbfz, headers);
+            }
             return callback(err, pbfz, headers);
         });
     });

--- a/index.js
+++ b/index.js
@@ -8,7 +8,6 @@ var immediate = global.setImmediate || process.nextTick;
 var mapnik_pool = require('mapnik-pool');
 var Pool = mapnik_pool.Pool;
 var os = require('os');
-var bytes = require('bytes');
 
 // Register datasource plugins
 mapnik.register_default_input_plugins();
@@ -248,7 +247,7 @@ Bridge.getVector = function(source, map, z, x, y, callback) {
 
 
     // The buffer size is in vector tile coordinates, while the buffer size on the
-    // map object is in image coordinates. Therefore, lets multiply the buffer_size 
+    // map object is in image coordinates. Therefore, lets multiply the buffer_size
     // by the old "path_multiplier" value of 16 to get a proper buffer size.
     try {
         // Try-catch is necessary here because the constructor will throw if x and y
@@ -257,7 +256,7 @@ Bridge.getVector = function(source, map, z, x, y, callback) {
     } catch(err) {
         return callback(err, null, headers);
     }
-    
+
     map.extent = vtile.extent();
 
     /*

--- a/index.js
+++ b/index.js
@@ -12,13 +12,16 @@ var os = require('os');
 // Register datasource plugins
 mapnik.register_default_input_plugins();
 
+// this will run on require, which means downstream users that are registering plugins
+// and include this environment variable will hit this section even if it is not desired
 if (process.env.BRIDGE_LOG_MAX_VTILE_BYTES_COMPRESSED) {
-    var stats = {max:0,total:0,count:0};
-
-    process.on('exit',function() {
+    var stats = { max:0, total:0, count:0 };
+    process.on('exit', function() {
         stats.avg = stats.total/stats.count;
-        fs.writeFileSync('tilelive-bridge-stats.json',JSON.stringify(stats,null,1));
-    })
+        if (stats.count > 0) {
+            fs.writeFileSync('tilelive-bridge-stats.json', JSON.stringify(stats));
+        }
+    });
 }
 
 

--- a/index.js
+++ b/index.js
@@ -13,12 +13,15 @@ var bytes = require('bytes');
 // Register datasource plugins
 mapnik.register_default_input_plugins();
 
-var stats = {max:0,total:0,count:0};
+if (process.env.BRIDGE_LOG_MAX_VTILE_BYTES_COMPRESSED) {
+    var stats = {max:0,total:0,count:0};
 
-process.on('exit',function() {
-    stats.avg = stats.total/stats.count;
-    fs.writeFileSync('stats.txt',JSON.stringify(stats));
-})
+    process.on('exit',function() {
+        stats.avg = stats.total/stats.count;
+        fs.writeFileSync('tilelive-bridge-stats.json',JSON.stringify(stats,null,1));
+    })
+}
+
 
 var mapnikPool = mapnik_pool(mapnik);
 

--- a/index.js
+++ b/index.js
@@ -8,6 +8,7 @@ var immediate = global.setImmediate || process.nextTick;
 var mapnik_pool = require('mapnik-pool');
 var Pool = mapnik_pool.Pool;
 var os = require('os');
+var bytes = require('bytes');
 
 // Register datasource plugins
 mapnik.register_default_input_plugins();
@@ -32,6 +33,7 @@ module.exports = Bridge;
 
 function Bridge(uri, callback) {
     this.BRIDGE_MAX_VTILE_BYTES_COMPRESSED = process.env.BRIDGE_MAX_VTILE_BYTES_COMPRESSED ? +process.env.BRIDGE_MAX_VTILE_BYTES_COMPRESSED : 0;
+    this.BRIDGE_LOG_MAX_VTILE_BYTES_COMPRESSED = process.env.BRIDGE_LOG_MAX_VTILE_BYTES_COMPRESSED ? +process.env.BRIDGE_LOG_MAX_VTILE_BYTES_COMPRESSED : 0;
     var source = this;
 
     if (typeof uri === 'string' || (uri.protocol && !uri.xml)) {
@@ -291,6 +293,9 @@ Bridge.getVector = function(source, map, z, x, y, callback) {
         vtile.getData({compression:'gzip'}, function(err, pbfz) {
             if (err) return callback(err);
             headers['Content-Encoding'] = 'gzip';
+            if (source.BRIDGE_LOG_MAX_VTILE_BYTES_COMPRESSED > 0 && pbfz.length > source.BRIDGE_LOG_MAX_VTILE_BYTES_COMPRESSED) {
+                console.log('large tile detected:',z,x,y,bytes(pbfz.length));
+            }
             if (source.BRIDGE_MAX_VTILE_BYTES_COMPRESSED > 0 && pbfz.length > source.BRIDGE_MAX_VTILE_BYTES_COMPRESSED) {
                 return callback(new Error("Tile >= max allowed size"), pbfz, headers);
             }

--- a/package.json
+++ b/package.json
@@ -14,7 +14,6 @@
   ],
   "dependencies": {
     "@mapbox/sphericalmercator": "~1.0.1",
-    "bytes": "^2.5.0",
     "mapnik": "~3.6.1",
     "mapnik-pool": "~0.1.3"
   },

--- a/package.json
+++ b/package.json
@@ -13,8 +13,9 @@
     }
   ],
   "dependencies": {
-    "mapnik": "~3.6.1",
     "@mapbox/sphericalmercator": "~1.0.1",
+    "bytes": "^2.5.0",
+    "mapnik": "~3.6.1",
     "mapnik-pool": "~0.1.3"
   },
   "devDependencies": {

--- a/test/test.js
+++ b/test/test.js
@@ -101,6 +101,20 @@ var rasterxml = {
             });
         });
     });
+    tape('should fail when tile generated is larger than max size', function(assert) {
+        new Bridge({ xml:xml.a, base:path.join(__dirname,'/') }, function(err, source) {
+            // monkeypatch the max tile size
+            source.BRIDGE_MAX_VTILE_BYTES_COMPRESSED = 1;
+            assert.equal(source.BRIDGE_MAX_VTILE_BYTES_COMPRESSED,1);
+            assert.ifError(err);
+            assert.ok(source);
+            source.getTile(0,0,0, function(err, buffer, headers) {
+                assert.equal(err.message, 'Tile >= max allowed size');
+                assert.ok(source.BRIDGE_MAX_VTILE_BYTES_COMPRESSED < buffer.length);
+                assert.end();
+            });
+        });
+    });
     tape('should load with callback', function(assert) {
         new Bridge({ xml: xml.a, base:path.join(__dirname,'/') }, function(err, source) {
             assert.ifError(err);


### PR DESCRIPTION
Adds the ability to:

 - set, via environment variable, the max vtile size allowed, in bytes.
 - log, via environment variable, tiles that are over a given size

Downstream consumers can opt into either of these options.

In the case of the max size error, the buffer is still passed in the callback. This allows downstream consumers to decide on the logic they want to use when this happens.