### PR TITLE
default to reasonable buffer size

### DIFF
--- a/index.js
+++ b/index.js
@@ -102,7 +102,7 @@ Bridge.prototype.update = function(opts, callback) {
         }
         this.close(function() {
             this._map = mapnikPool.fromString(this._xml,
-                { size: 256, bufferSize: 256 },
+                { size: 256, bufferSize: 5 },
                 mopts);
             this._im = ImagePool(512);
             return callback();


### PR DESCRIPTION
The default `256` buffer size is overly large. We should default to something much smaller, like 5 (which is the default in tippecanoe). Most Mapnik vector tile renders will and should override this value in the mapnik XML by setting the `buffer-size` on the `Layer`. This value is then ignored, which has always been the case for tilelive-omnivore usage of tilelive-bridge. But nevertheless this default is too large.

refs https://github.com/mapbox/tilelive-omnivore/pull/45

Refs #87