### PR TITLE
back mapnik down to 3.6.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   ],
   "dependencies": {
     "@mapbox/sphericalmercator": "~1.0.1",
-    "mapnik": "~3.6.1",
+    "mapnik": "~3.6.0",
     "mapnik-pool": "~0.1.3"
   },
   "devDependencies": {


### PR DESCRIPTION
Having mapnik at 3.6.1 meant all downstreamers needed to use this version, which hurts. Let's allow for downstreams to use whichever patch version they want, including 3.6.0

cc @GretaCB @flippmoke 