### PR TITLE
collect stats for tif files

### DIFF
--- a/index.js
+++ b/index.js
@@ -236,6 +236,16 @@ Bridge.getRaster = function(source, map, im, z, x, y, callback) {
                     return callback(err);
                 }
                 buffer.solid = pixel_key;
+
+                // collect stats for raster data
+                if (source.BRIDGE_LOG_MAX_VTILE_BYTES_COMPRESSED > 0 && buffer.length > source.BRIDGE_LOG_MAX_VTILE_BYTES_COMPRESSED) {
+                    stats.count++;
+                    stats.total = stats.total + (buffer.length*0.001);
+                    if (stats.max < buffer.length) {
+                        stats.max = buffer.length;
+                    }
+                }
+
                 return callback(err, buffer, {'Content-Type':'image/webp'});
             });
         });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mapbox/tilelive-bridge",
-  "version": "3.2.0",
+  "version": "3.2.1",
   "main": "./index.js",
   "description": "Datasource => vector tiles bridge backend for tilelive",
   "repository": {


### PR DESCRIPTION
Using the same `BRIDGE_LOG_MAX_VTILE_BYTES_COMPRESSED` environment variable to collect stats. 

Recognize the naming is a bit off - but we can fix that in a major release if necessary.

cc @suhasdeshpande 